### PR TITLE
Make this lib useable in deno tests

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,7 @@
 import { bgGreen, bgWhite, writeAllSync } from "./deps.ts";
 export { MultiProgressBar } from "./multi.ts";
 
-const isTTY = Deno.stdout && Deno.isatty(Deno.stdout.rid);
+const hasStdout = Deno.stdout;
 const isWindow = Deno.build.os === "windows";
 
 const enum Direction {
@@ -94,7 +94,7 @@ export default class ProgressBar {
    *   - `incomplete` - incomplete character, If you want to change at a certain moment. For example, it turns red at 20%
    */
   render(completed: number, options: renderOptions = {}): void {
-    if (this.isCompleted || !isTTY) return;
+    if (this.isCompleted || !hasStdout) return;
 
     if (completed < 0) {
       throw new Error(`completed must greater than or equal to 0`);

--- a/tests/mod.test.ts
+++ b/tests/mod.test.ts
@@ -1,0 +1,15 @@
+import ProgressBar from "../mod.ts";
+import { simpleTimerStream } from "https://deno.land/x/simple_timer_stream@1.0.0/mod.ts";
+
+Deno.test(`Use ProgressBar in a deno test`, async () => {
+  const progress = new ProgressBar({ title: "downloading: ", total: 100 });
+
+  const timer = simpleTimerStream({
+    maxEventCount: 100,
+    intervalInMilliseconds: 50,
+  });
+
+  for await (const event of timer) {
+    progress.render(event);
+  }
+});


### PR DESCRIPTION
This PR makes this lib useable in deno tests by only checking for the availability of Deno.stdout without checking for isTTY. 

Fixes Issue #13 in original repo