### PR TITLE
Support for custom writer and units template token

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ interface renderOptions {
   complete?: string;
   incomplete?: string;
   prettyTimeOptions?: prettyTimeOptions;
+  units?: string;
 }
 
 /**
@@ -156,6 +157,7 @@ class MultiProgressBar {
    * @param interval  minimum time between updates in milliseconds, default: 16
    * @param display  What is displayed and display order, default: ':bar :text :percent :time :completed/:total'
    * @param prettyTime Whether to pretty print time and eta
+   * @param units 
    * @param writer Optional `Deno.WriterSync` to use for output, default: `Deno.stdout`
    */
   constructor(optopns: ConstructorOptions);
@@ -170,6 +172,7 @@ class MultiProgressBar {
    * @param bars.complete optional, completion character
    * @param bars.incomplete optional, incomplete character
    * @param bars.prettyTimeOptions optional, prettyTime options
+   * @param bars.units optional, text to use for `:units` token, default: ''
    */
   render(bars: Array<renderOptions>): void;
 
@@ -199,6 +202,7 @@ What is displayed and display order, default: ':bar :text :percent :time :comple
 * `:eta` estimated completion time in seconds
 * `:total` total number of ticks to complete
 * `:completed` completed value
+* `:units` the units of a tick
 
 ### Single progress bar
 
@@ -273,6 +277,7 @@ interface ConstructorOptions {
   interval?: number,
   display?: string
   prettyTime?: boolean;
+  units?: string;
   writer?: Deno.WriterSync;
 }
 
@@ -311,6 +316,7 @@ class ProgressBar {
    * @param interval  minimum time between updates in milliseconds, default: 16
    * @param display  What is displayed and display order, default: ':title :percent :bar :time :completed/:total'
    * @param prettyTime Whether to pretty print time and eta
+   * @param bars.units Optional text to use for `:units` token, default: ''
    * @param writer Optional `Deno.WriterSync` to use for output, default: `Deno.stdout`
    */
   constructor(optopns: ConstructorOptions): void;
@@ -354,6 +360,7 @@ What is displayed and display order, default: ':title :percent :bar :time :compl
 * `:eta` estimated completion time in seconds
 * `:completed` completed value
 * `:total` total number of ticks to complete
+* `:units` the units of a tick
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -157,10 +157,9 @@ class MultiProgressBar {
    * @param interval  minimum time between updates in milliseconds, default: 16
    * @param display  What is displayed and display order, default: ':bar :text :percent :time :completed/:total'
    * @param prettyTime Whether to pretty print time and eta
-   * @param units 
    * @param writer Optional `Deno.WriterSync` to use for output, default: `Deno.stdout`
    */
-  constructor(optopns: ConstructorOptions);
+  constructor(options: ConstructorOptions);
 
   /**
    * "render" the progress bar
@@ -316,7 +315,7 @@ class ProgressBar {
    * @param interval  minimum time between updates in milliseconds, default: 16
    * @param display  What is displayed and display order, default: ':title :percent :bar :time :completed/:total'
    * @param prettyTime Whether to pretty print time and eta
-   * @param bars.units Optional text to use for `:units` token, default: ''
+   * @param units Optional text to use for `:units` token, default: ''
    * @param writer Optional `Deno.WriterSync` to use for output, default: `Deno.stdout`
    */
   constructor(optopns: ConstructorOptions): void;

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ interface constructorOptions {
   interval?: number;
   display?: string;
   prettyTime?: boolean;
+  writer?: Deno.WriterSync;
 }
 
 interface renderOptions {
@@ -155,6 +156,7 @@ class MultiProgressBar {
    * @param interval  minimum time between updates in milliseconds, default: 16
    * @param display  What is displayed and display order, default: ':bar :text :percent :time :completed/:total'
    * @param prettyTime Whether to pretty print time and eta
+   * @param writer Optional `Deno.WriterSync` to use for output, default: `Deno.stdout`
    */
   constructor(optopns: ConstructorOptions);
 
@@ -271,6 +273,7 @@ interface ConstructorOptions {
   interval?: number,
   display?: string
   prettyTime?: boolean;
+  writer?: Deno.WriterSync;
 }
 
 interface renderOptions {
@@ -308,6 +311,7 @@ class ProgressBar {
    * @param interval  minimum time between updates in milliseconds, default: 16
    * @param display  What is displayed and display order, default: ':title :percent :bar :time :completed/:total'
    * @param prettyTime Whether to pretty print time and eta
+   * @param writer Optional `Deno.WriterSync` to use for output, default: `Deno.stdout`
    */
   constructor(optopns: ConstructorOptions): void;
 

--- a/multi.ts
+++ b/multi.ts
@@ -22,6 +22,7 @@ interface renderOptions {
   complete?: string;
   incomplete?: string;
   prettyTimeOptions?: prettyTimeOptions;
+  units?: string;
 }
 
 interface bar {
@@ -108,6 +109,7 @@ export class MultiProgressBar {
    *   - `complete` - optional, completion character
    *   - `incomplete` - optional, incomplete character
    *   - `prettyTimeOptions` - prettyTime options
+   *   - `units` - optional, text to use for `:units` token, default: ''
    */
   render(bars: Array<renderOptions>): void {
     if (this.#end || !this.writer) return;
@@ -149,7 +151,8 @@ export class MultiProgressBar {
         .replace(":eta", eta)
         .replace(":percent", percent)
         .replace(":completed", completed + "")
-        .replace(":total", total + "");
+        .replace(":total", total + "")
+        .replace(":units", options.units ?? "");
 
       // compute the available space (non-zero) for the bar
       let availableSpace = Math.max(
@@ -235,7 +238,8 @@ export class MultiProgressBar {
 
   private get ttyColumns(): number {
     // fix (os error 6) for deno test in wondows
-    if (isWindows && this.writer.rid && !Deno.isatty(this.writer.rid)) return 100;
+    const rid = (this.writer as unknown as { rid: number}).rid;
+    if (isWindows && (rid !== undefined) && !Deno.isatty(rid)) return 100;
     return Deno.consoleSize().columns;
   }
 

--- a/multi.ts
+++ b/multi.ts
@@ -237,7 +237,7 @@ export class MultiProgressBar {
   }
 
   private get ttyColumns(): number {
-    // fix (os error 6) for deno test in wondows
+    // fix (os error 6) for deno test in windows
     const rid = (this.writer as unknown as { rid: number}).rid;
     if (isWindows && (rid !== undefined) && !Deno.isatty(rid)) return 100;
     return Deno.consoleSize().columns;


### PR DESCRIPTION
- feature: add support for passing custom `Deno.WriterSync` i.e. to allow output to `Deno.stderr`
- feature: add support for `:units` template field