### PR TITLE
chore: update to latest stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ ProgressBar in terminal for deno
 
 ## Update
 
+### v1.4.0 - 2023.11.12
+
+update to use [deno standard library v0.206.0](https://deno.land/std@0.206.0)
+
 ### v1.3.9 - 2023.08.31
 
 fixed [Incorrect bar size when color is used in the title](https://github.com/deno-library/progress/issues/24)

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export {
   bgGreen,
   bgWhite,
-  stripColor,
-} from "https://deno.land/std@0.162.0/fmt/colors.ts";
-export { writeAllSync } from "https://deno.land/std@0.162.0/streams/conversion.ts";
+  stripAnsiCode
+} from "https://deno.land/std@0.206.0/fmt/colors.ts";
+export { writeAllSync } from "https://deno.land/std@0.206.0/streams/write_all.ts";

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,0 +1,3 @@
+export { assertEquals } from "https://deno.land/std@0.206.0/assert/mod.ts";
+export { delay } from "https://deno.land/std@0.206.0/async/delay.ts";
+export { simpleTimerStream } from "https://deno.land/x/simple_timer_stream@1.0.2/mod.ts";

--- a/example_deps.ts
+++ b/example_deps.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.206.0/fmt/colors.ts";

--- a/examples/changeBgColor.ts
+++ b/examples/changeBgColor.ts
@@ -2,7 +2,7 @@ import ProgressBar from "../mod.ts";
 import {
   bgMagenta,
   bgCyan,
-} from "https://deno.land/std@0.74.0/fmt/colors.ts";
+} from "../example_deps.ts";
 
 const total = 100;
 

--- a/examples/changeColor.ts
+++ b/examples/changeColor.ts
@@ -2,7 +2,7 @@ import ProgressBar from "../mod.ts";
 import {
   yellow,
   green,
-} from "https://deno.land/std@0.74.0/fmt/colors.ts";
+} from "../example_deps.ts";
 
 const total = 100;
 

--- a/examples/colorProgression.ts
+++ b/examples/colorProgression.ts
@@ -1,5 +1,5 @@
 import ProgressBar from "../mod.ts";
-import { bgRgb24 } from "https://deno.land/std@0.74.0/fmt/colors.ts";
+import { bgRgb24 } from "../example_deps.ts";
 
 const total = 100;
 

--- a/examples/preciseBar.ts
+++ b/examples/preciseBar.ts
@@ -2,7 +2,7 @@ import ProgressBar from "../mod.ts";
 import {
   bgWhite,
   green,
-} from "https://deno.land/std@0.141.0/fmt/colors.ts";
+} from "../example_deps.ts";
 
 const total = 100;
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { bgGreen, bgWhite, stripColor, writeAllSync } from "./deps.ts";
+import { bgGreen, bgWhite, stripAnsiCode, writeAllSync } from "./deps.ts";
 import { prettyTime, prettyTimeOptions } from "./time.ts";
 export { MultiProgressBar } from "./multi.ts";
 
@@ -154,7 +154,7 @@ export default class ProgressBar {
     // compute the available space (non-zero) for the bar
     const availableSpace = Math.max(
       0,
-      this.ttyColumns - stripColor(str.replace(":bar", "")).length,
+      this.ttyColumns - stripAnsiCode(str.replace(":bar", "")).length,
     );
 
     const width = Math.min(this.width, availableSpace);
@@ -185,7 +185,7 @@ export default class ProgressBar {
     str = str.replace(":bar", complete + precise + incomplete);
 
     if (str !== this.lastStr) {
-      const strLen = stripColor(str).length;
+      const strLen = stripAnsiCode(str).length;
       if (strLen < this.lastStrLen) {
         str += " ".repeat(this.lastStrLen - strLen);
       }

--- a/multi.ts
+++ b/multi.ts
@@ -1,4 +1,4 @@
-import { bgGreen, bgWhite, stripColor, writeAllSync } from "./deps.ts";
+import { bgGreen, bgWhite, stripAnsiCode, writeAllSync } from "./deps.ts";
 import { prettyTime, prettyTimeOptions } from "./time.ts";
 
 const hasStdout = Deno.stdout;
@@ -149,9 +149,9 @@ export class MultiProgressBar {
       // compute the available space (non-zero) for the bar
       const availableSpace = Math.max(
         0,
-        this.ttyColumns - stripColor(str.replace(":bar", "")).length,
+        this.ttyColumns - stripAnsiCode(str.replace(":bar", "")).length,
       );
-      
+
       const width = Math.min(this.width, availableSpace);
       // :bar
       const completeLength = Math.round(width * completed / total);
@@ -163,7 +163,7 @@ export class MultiProgressBar {
       ).join("");
 
       str = str.replace(":bar", complete + incomplete);
-      const strLen = stripColor(str).length;
+      const strLen = stripAnsiCode(str).length;
       if (this.#bars[index] && str != this.#bars[index].str) {
         const lastStrLen = this.#bars[index].strLen!;
         if (strLen < lastStrLen) {

--- a/tests/mod.test.ts
+++ b/tests/mod.test.ts
@@ -1,5 +1,5 @@
 import ProgressBar from "../mod.ts";
-import { simpleTimerStream } from "https://deno.land/x/simple_timer_stream@1.0.0/mod.ts";
+import { simpleTimerStream } from "../dev_deps.ts";
 
 Deno.test(`Use ProgressBar in a deno test`, async () => {
   const progress = new ProgressBar({ title: "downloading: ", total: 50 });

--- a/tests/multi.test.ts
+++ b/tests/multi.test.ts
@@ -1,5 +1,5 @@
 import { MultiProgressBar } from "../mod.ts";
-import { delay } from "https://deno.land/std@0.177.0/async/delay.ts";
+import { delay } from "../dev_deps.ts";
 
 Deno.test(`Use MultiProgressBar in a deno test`, async () => {
   const title = "download files";

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -1,5 +1,5 @@
 import { prettyTime } from "../time.ts";
-import { assertEquals } from "https://deno.land/std@0.162.0/testing/asserts.ts";
+import { assertEquals } from "../dev_deps.ts";
 
 Deno.test(`test prettyTime: default`, () => {
   // assertEquals(prettyTime(10), "10.0s");


### PR DESCRIPTION
This updates everything to use the latest standard library `v0.206.0`.

- `stripColor` is deprecated and replaced by `stripAnsiCode`
- `writeAllSync` was moved from `std/streams/conversion.ts` to `std/streams/write_all.ts`
- created an `example_deps.ts` file and updated examples to use this versus direct urls.

NOTE: The [writeAllSync](https://deno.land/std@0.206.0/streams/write_all.ts?s=writeAllSync) function is also marked as deprecated and will be removed in stdlib v1. However, there does not seem to be any direct mapping to use the Web Streams API to a synchronous version as far as I can tell. Therefore I think this will require a larger change to make this asynchronous. So this was left out from these changes.